### PR TITLE
Sync netmhcstabandpan subworkflow with PR mskcc-omics-workflows/modul…

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -100,8 +100,8 @@
                         "installed_by": ["subworkflows"]
                     },
                     "netmhcstabandpan": {
-                        "branch": "neoantigen",
-                        "git_sha": "cd48156aed141b00fedf1bc887966ad4664ba001",
+                        "branch": "develop",
+                        "git_sha": "42c230a46733aa3f2d39ba86014e7129c13d860a",
                         "installed_by": ["subworkflows"]
                     },
                     "phylowgs": {

--- a/subworkflows/msk/netmhcstabandpan/main.nf
+++ b/subworkflows/msk/netmhcstabandpan/main.nf
@@ -58,16 +58,19 @@ def createNETMHCInput(fastas_and_hla, sv_fastas) {
                 [it[0],it]
                 }
 
+        // remainder: true keeps samples that have no SV data (sv_fastas is empty when no SVs provided)
         def merged_mut = fastas_and_hla_channel
-            .join(sv_fastas_channel, by:0)
+            .join(sv_fastas_channel, by:0, remainder: true)
             .map({
-                [it[1][0], it[1][1], it[2][1], it[1][3], "MUT"]
+                def sv = it[2] ?: [null, [], []]
+                [it[1][0], it[1][1], sv[1], it[1][3], "MUT"]
             })
 
         def merged_wt = fastas_and_hla_channel
-            .join(sv_fastas_channel, by:0)
+            .join(sv_fastas_channel, by:0, remainder: true)
             .map({
-                [it[1][0], it[1][2], it[2][2], it[1][3], "WT"]
+                def sv = it[2] ?: [null, [], []]
+                [it[1][0], it[1][2], sv[2], it[1][3], "WT"]
             })
         def merged = merged_mut.mix(merged_wt)
         return merged

--- a/subworkflows/msk/netmhcstabandpan/tests/main.nf.test
+++ b/subworkflows/msk/netmhcstabandpan/tests/main.nf.test
@@ -162,6 +162,43 @@ nextflow_workflow {
     }
 
 
+    test("netmhcstabandpan - empty SV channel - fa,hla_str - tsv - stub") {
+
+        // Regression test: when no SV files are provided, the upstream NEOSV process
+        // doesn't run, so the sv_fasta channel emits zero items. The createNETMHCInput
+        // helper must still emit MUT and WT tuples for each sample.
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.value([
+                    [ id:'test', single_end:false ], // meta map
+                    file('MUT_sequence_fa', checkIfExists: false),
+                    file('WT_sequence_fa', checkIfExists: false),
+                    "HLA-A24:02,HLA-A24:02,HLA-B39:01,HLA-B39:01,HLA-C07:01,HLA-C06:02",
+                    ])
+
+                input[1] = channel.empty()
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(workflow.out.tsv[0][0],
+                                  file(workflow.out.tsv[0][1]).name,
+                                  workflow.out.tsv[1][0],
+                                  file(workflow.out.tsv[1][1]).name
+                                  ).match()
+                }
+            )
+        }
+    }
+
+
     test("netmhcstabandpan - fa,hla_str - tsv - stub") {
 
         options "-stub"

--- a/subworkflows/msk/netmhcstabandpan/tests/main.nf.test.snap
+++ b/subworkflows/msk/netmhcstabandpan/tests/main.nf.test.snap
@@ -212,5 +212,30 @@
             "nextflow": "25.10.2"
         },
         "timestamp": "2025-12-19T14:22:41.854041255"
+    },
+    "netmhcstabandpan - empty SV channel - fa,hla_str - tsv - stub": {
+        "content": [
+            {
+                "id": "test",
+                "single_end": false,
+                "typeMut": false,
+                "fromStab": false,
+                "typePan": true
+            },
+            "test.WT.PAN.tsv",
+            {
+                "id": "test",
+                "single_end": false,
+                "typeMut": false,
+                "fromStab": true,
+                "typePan": true
+            },
+            "test.WT.STAB.tsv"
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.2"
+        },
+        "timestamp": "2026-05-13T22:29:19.315483"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -151,8 +151,30 @@
                 "MUTALYZER_RETRIEVER": {
                     "mutalyzer": "3.1.1"
                 },
+                "NEOANTIGENEDITING_ALIGNTOIEDB": {
+                    "neoantigenEditing": 1.3
+                },
+                "NEOANTIGENEDITING_COMPUTEFITNESS": {
+                    "neoantigenEditing": 1.3
+                },
+                "NEOANTIGENUTILS_CONVERTANNOTJSON": {
+                    "convertannotjson": "v1.1"
+                },
+                "NEOANTIGENUTILS_FORMATNETMHCPAN": {
+                    "formatNetmhcpanOutput": "format_netmhcpan_output.py 1.0"
+                },
                 "NEOANTIGENUTILS_GENERATEHLASTRING": {
                     "generateHLAstring": "1.0.0"
+                },
+                "NEOANTIGENUTILS_NEOANTIGENINPUT": {
+                    "neoantigeninput": "generate_input.py 1.9"
+                },
+                "NETMHC3": {
+                    "netmhc": "v3.4"
+                },
+                "NETMHCSTABPAN": {
+                    "netmhcpan": "v4.1",
+                    "netmhcstabpan": "v1.0"
                 },
                 "PHYLOWGS_CREATEINPUT": {
                     "phylowgs": "v1.5-msk"
@@ -185,7 +207,26 @@
                 "tumor_normal/generatemutfasta/tumor_normal_out/tumor_normal.MUT.sequences.fa",
                 "tumor_normal/generatemutfasta/tumor_normal_out/tumor_normal.WT.sequences.fa",
                 "tumor_normal/generatemutfasta/tumor_normal_out/tumor_normal_generate_mut_fasta.log",
+                "tumor_normal/neoantigenediting",
+                "tumor_normal/neoantigenediting/iedb_alignments_tumor_normal_patient.txt",
+                "tumor_normal/neoantigenediting/tumor_normal_patient_tumor_normal_input_annotated.json",
                 "tumor_normal/neoantigenutils",
+                "tumor_normal/neoantigenutils/tumor_normal_neoantigens.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_netmhc.output.MUT.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_netmhc.output.WT.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_netmhcstabpan.output.MUT.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_netmhcstabpan.output.WT.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_patient_tumor_normal_input.json",
+                "tumor_normal/netmhc3",
+                "tumor_normal/netmhc3/tumor_normal.MUT.netmhc.output",
+                "tumor_normal/netmhc3/tumor_normal.MUT.xls",
+                "tumor_normal/netmhc3/tumor_normal.WT.netmhc.output",
+                "tumor_normal/netmhc3/tumor_normal.WT.xls",
+                "tumor_normal/netmhc3/tumor_normal.hla_accepted.txt",
+                "tumor_normal/netmhc3/tumor_normal.hla_rejected.txt",
+                "tumor_normal/netmhcstabpan",
+                "tumor_normal/netmhcstabpan/tumor_normal.MUT.netmhcstabpan.output",
+                "tumor_normal/netmhcstabpan/tumor_normal.WT.netmhcstabpan.output",
                 "tumor_normal/phylowgs",
                 "tumor_normal/phylowgs/chains",
                 "tumor_normal/phylowgs/chains/trees.zip",
@@ -201,7 +242,26 @@
                 "tumor_normal2/generatemutfasta/tumor_normal2_out/tumor_normal2.MUT.sequences.fa",
                 "tumor_normal2/generatemutfasta/tumor_normal2_out/tumor_normal2.WT.sequences.fa",
                 "tumor_normal2/generatemutfasta/tumor_normal2_out/tumor_normal2_generate_mut_fasta.log",
+                "tumor_normal2/neoantigenediting",
+                "tumor_normal2/neoantigenediting/iedb_alignments_tumor_normal2_patient.txt",
+                "tumor_normal2/neoantigenediting/tumor_normal2_patient_tumor_normal2_input_annotated.json",
                 "tumor_normal2/neoantigenutils",
+                "tumor_normal2/neoantigenutils/tumor_normal2_neoantigens.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_netmhc.output.MUT.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_netmhc.output.WT.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_netmhcstabpan.output.MUT.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_netmhcstabpan.output.WT.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_patient_tumor_normal2_input.json",
+                "tumor_normal2/netmhc3",
+                "tumor_normal2/netmhc3/tumor_normal2.MUT.netmhc.output",
+                "tumor_normal2/netmhc3/tumor_normal2.MUT.xls",
+                "tumor_normal2/netmhc3/tumor_normal2.WT.netmhc.output",
+                "tumor_normal2/netmhc3/tumor_normal2.WT.xls",
+                "tumor_normal2/netmhc3/tumor_normal2.hla_accepted.txt",
+                "tumor_normal2/netmhc3/tumor_normal2.hla_rejected.txt",
+                "tumor_normal2/netmhcstabpan",
+                "tumor_normal2/netmhcstabpan/tumor_normal2.MUT.netmhcstabpan.output",
+                "tumor_normal2/netmhcstabpan/tumor_normal2.WT.netmhcstabpan.output",
                 "tumor_normal2/phylowgs",
                 "tumor_normal2/phylowgs/chains",
                 "tumor_normal2/phylowgs/chains/trees.zip",
@@ -216,11 +276,27 @@
                 "versions.yml:md5,88999809ef25538868f353fda1c397f1",
                 "tumor_normal.MUT.sequences.fa:md5,3d2ff66590a4329f9a24e03bdf84e0ab",
                 "tumor_normal.WT.sequences.fa:md5,4bfcfc4d29d01ddc4108f39350936228",
+                "iedb_alignments_tumor_normal_patient.txt:md5,30b3edf8705b335a360ba428501388da",
+                "tumor_normal_neoantigens.tsv:md5,8565ba43904eb5ee0732875ce1bcf565",
+                "tumor_normal_netmhc.output.MUT.tsv:md5,3bb2e5167ae1211f7872650c53c7f816",
+                "tumor_normal_netmhc.output.WT.tsv:md5,f0fbd063b1bb18a8be0c1716e7500bb8",
+                "tumor_normal_netmhcstabpan.output.MUT.tsv:md5,3405a5776e2dbb95906ca97a0cabfddf",
+                "tumor_normal_netmhcstabpan.output.WT.tsv:md5,98d97fc3e16b4bcccfbacb056b6ab5a4",
+                "tumor_normal.hla_accepted.txt:md5,ccc4b3e5c2a2c7cad3581bfc72ef8106",
+                "tumor_normal.hla_rejected.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "cnv_data.txt:md5,ac0eef7efce9b76adc381891f9156850",
                 "cnvs.txt:md5,9c7f21a42d5a2225b1224deec3f77a24",
                 "ssm_data.txt:md5,23ef29d9231d13586b5ef42c1b90e330",
                 "tumor_normal2.MUT.sequences.fa:md5,3d2ff66590a4329f9a24e03bdf84e0ab",
                 "tumor_normal2.WT.sequences.fa:md5,4bfcfc4d29d01ddc4108f39350936228",
+                "iedb_alignments_tumor_normal2_patient.txt:md5,30b3edf8705b335a360ba428501388da",
+                "tumor_normal2_neoantigens.tsv:md5,8565ba43904eb5ee0732875ce1bcf565",
+                "tumor_normal2_netmhc.output.MUT.tsv:md5,3bb2e5167ae1211f7872650c53c7f816",
+                "tumor_normal2_netmhc.output.WT.tsv:md5,f0fbd063b1bb18a8be0c1716e7500bb8",
+                "tumor_normal2_netmhcstabpan.output.MUT.tsv:md5,3405a5776e2dbb95906ca97a0cabfddf",
+                "tumor_normal2_netmhcstabpan.output.WT.tsv:md5,98d97fc3e16b4bcccfbacb056b6ab5a4",
+                "tumor_normal2.hla_accepted.txt:md5,ccc4b3e5c2a2c7cad3581bfc72ef8106",
+                "tumor_normal2.hla_rejected.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "cnv_data.txt:md5,ac0eef7efce9b76adc381891f9156850",
                 "cnvs.txt:md5,9c7f21a42d5a2225b1224deec3f77a24",
                 "ssm_data.txt:md5,23ef29d9231d13586b5ef42c1b90e330"
@@ -230,6 +306,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-24T12:52:00.2956958"
+        "timestamp": "2026-05-15T13:34:45.00724"
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -9,8 +9,30 @@
                 "MUTALYZER_RETRIEVER": {
                     "mutalyzer": "3.1.1"
                 },
+                "NEOANTIGENEDITING_ALIGNTOIEDB": {
+                    "neoantigenEditing": 1.3
+                },
+                "NEOANTIGENEDITING_COMPUTEFITNESS": {
+                    "neoantigenEditing": 1.3
+                },
+                "NEOANTIGENUTILS_CONVERTANNOTJSON": {
+                    "convertannotjson": "v1.1"
+                },
+                "NEOANTIGENUTILS_FORMATNETMHCPAN": {
+                    "formatNetmhcpanOutput": "format_netmhcpan_output.py 1.0"
+                },
                 "NEOANTIGENUTILS_GENERATEHLASTRING": {
                     "generateHLAstring": "1.0.0"
+                },
+                "NEOANTIGENUTILS_NEOANTIGENINPUT": {
+                    "neoantigeninput": "generate_input.py 1.9"
+                },
+                "NETMHC3": {
+                    "netmhc": "v3.4"
+                },
+                "NETMHCSTABPAN": {
+                    "netmhcpan": "v4.1",
+                    "netmhcstabpan": "v1.0"
                 },
                 "PHYLOWGS_STUB": {
                     "phylowgs_stub": "1.0"
@@ -34,7 +56,26 @@
                 "tumor_normal/generatemutfasta/tumor_normal_out/tumor_normal.MUT.sequences.fa",
                 "tumor_normal/generatemutfasta/tumor_normal_out/tumor_normal.WT.sequences.fa",
                 "tumor_normal/generatemutfasta/tumor_normal_out/tumor_normal_generate_mut_fasta.log",
+                "tumor_normal/neoantigenediting",
+                "tumor_normal/neoantigenediting/iedb_alignments_tumor_normal_patient.txt",
+                "tumor_normal/neoantigenediting/tumor_normal_patient_tumor_normal_input_annotated.json",
                 "tumor_normal/neoantigenutils",
+                "tumor_normal/neoantigenutils/tumor_normal_neoantigens.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_netmhc.output.MUT.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_netmhc.output.WT.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_netmhcstabpan.output.MUT.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_netmhcstabpan.output.WT.tsv",
+                "tumor_normal/neoantigenutils/tumor_normal_patient_tumor_normal_input.json",
+                "tumor_normal/netmhc3",
+                "tumor_normal/netmhc3/tumor_normal.MUT.netmhc.output",
+                "tumor_normal/netmhc3/tumor_normal.MUT.xls",
+                "tumor_normal/netmhc3/tumor_normal.WT.netmhc.output",
+                "tumor_normal/netmhc3/tumor_normal.WT.xls",
+                "tumor_normal/netmhc3/tumor_normal.hla_accepted.txt",
+                "tumor_normal/netmhc3/tumor_normal.hla_rejected.txt",
+                "tumor_normal/netmhcstabpan",
+                "tumor_normal/netmhcstabpan/tumor_normal.MUT.netmhcstabpan.output",
+                "tumor_normal/netmhcstabpan/tumor_normal.WT.netmhcstabpan.output",
                 "tumor_normal/phylowgs",
                 "tumor_normal/phylowgs/tumor_normal.mutass.zip",
                 "tumor_normal/phylowgs/tumor_normal.muts.json.gz",
@@ -45,7 +86,26 @@
                 "tumor_normal2/generatemutfasta/tumor_normal2_out/tumor_normal2.MUT.sequences.fa",
                 "tumor_normal2/generatemutfasta/tumor_normal2_out/tumor_normal2.WT.sequences.fa",
                 "tumor_normal2/generatemutfasta/tumor_normal2_out/tumor_normal2_generate_mut_fasta.log",
+                "tumor_normal2/neoantigenediting",
+                "tumor_normal2/neoantigenediting/iedb_alignments_tumor_normal2_patient.txt",
+                "tumor_normal2/neoantigenediting/tumor_normal2_patient_tumor_normal2_input_annotated.json",
                 "tumor_normal2/neoantigenutils",
+                "tumor_normal2/neoantigenutils/tumor_normal2_neoantigens.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_netmhc.output.MUT.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_netmhc.output.WT.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_netmhcstabpan.output.MUT.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_netmhcstabpan.output.WT.tsv",
+                "tumor_normal2/neoantigenutils/tumor_normal2_patient_tumor_normal2_input.json",
+                "tumor_normal2/netmhc3",
+                "tumor_normal2/netmhc3/tumor_normal2.MUT.netmhc.output",
+                "tumor_normal2/netmhc3/tumor_normal2.MUT.xls",
+                "tumor_normal2/netmhc3/tumor_normal2.WT.netmhc.output",
+                "tumor_normal2/netmhc3/tumor_normal2.WT.xls",
+                "tumor_normal2/netmhc3/tumor_normal2.hla_accepted.txt",
+                "tumor_normal2/netmhc3/tumor_normal2.hla_rejected.txt",
+                "tumor_normal2/netmhcstabpan",
+                "tumor_normal2/netmhcstabpan/tumor_normal2.MUT.netmhcstabpan.output",
+                "tumor_normal2/netmhcstabpan/tumor_normal2.WT.netmhcstabpan.output",
                 "tumor_normal2/phylowgs",
                 "tumor_normal2/phylowgs/tumor_normal2.mutass.zip",
                 "tumor_normal2/phylowgs/tumor_normal2.muts.json.gz",
@@ -55,15 +115,31 @@
                 "versions.yml:md5,88999809ef25538868f353fda1c397f1",
                 "tumor_normal.MUT.sequences.fa:md5,3d2ff66590a4329f9a24e03bdf84e0ab",
                 "tumor_normal.WT.sequences.fa:md5,4bfcfc4d29d01ddc4108f39350936228",
+                "iedb_alignments_tumor_normal_patient.txt:md5,30b3edf8705b335a360ba428501388da",
+                "tumor_normal_neoantigens.tsv:md5,8565ba43904eb5ee0732875ce1bcf565",
+                "tumor_normal_netmhc.output.MUT.tsv:md5,3bb2e5167ae1211f7872650c53c7f816",
+                "tumor_normal_netmhc.output.WT.tsv:md5,f0fbd063b1bb18a8be0c1716e7500bb8",
+                "tumor_normal_netmhcstabpan.output.MUT.tsv:md5,3405a5776e2dbb95906ca97a0cabfddf",
+                "tumor_normal_netmhcstabpan.output.WT.tsv:md5,98d97fc3e16b4bcccfbacb056b6ab5a4",
+                "tumor_normal.hla_accepted.txt:md5,ccc4b3e5c2a2c7cad3581bfc72ef8106",
+                "tumor_normal.hla_rejected.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "tumor_normal2.MUT.sequences.fa:md5,3d2ff66590a4329f9a24e03bdf84e0ab",
-                "tumor_normal2.WT.sequences.fa:md5,4bfcfc4d29d01ddc4108f39350936228"
+                "tumor_normal2.WT.sequences.fa:md5,4bfcfc4d29d01ddc4108f39350936228",
+                "iedb_alignments_tumor_normal2_patient.txt:md5,30b3edf8705b335a360ba428501388da",
+                "tumor_normal2_neoantigens.tsv:md5,8565ba43904eb5ee0732875ce1bcf565",
+                "tumor_normal2_netmhc.output.MUT.tsv:md5,3bb2e5167ae1211f7872650c53c7f816",
+                "tumor_normal2_netmhc.output.WT.tsv:md5,f0fbd063b1bb18a8be0c1716e7500bb8",
+                "tumor_normal2_netmhcstabpan.output.MUT.tsv:md5,3405a5776e2dbb95906ca97a0cabfddf",
+                "tumor_normal2_netmhcstabpan.output.WT.tsv:md5,98d97fc3e16b4bcccfbacb056b6ab5a4",
+                "tumor_normal2.hla_accepted.txt:md5,ccc4b3e5c2a2c7cad3581bfc72ef8106",
+                "tumor_normal2.hla_rejected.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.4"
         },
-        "timestamp": "2026-04-24T12:49:38.529887705"
+        "timestamp": "2026-05-15T00:02:39.48102"
     },
     "-profile test_full": {
         "content": [


### PR DESCRIPTION
## Summary
- Syncs the `msk/netmhcstabandpan` subworkflow to track the merged fix in [mskcc-omics-workflows/modules#246](https://github.com/mskcc-omics-workflows/modules/pull/246).
- `modules.json` now tracks the `develop` branch at SHA `42c230a4` (the merge commit). The fix landed on `develop`, not `neoantigen`, so the tracking branch is updated accordingly.
- The subworkflow's channel join now uses `remainder: true` with null-coalescing so samples without SV input are no longer silently dropped from the netMHC MUT/WT tuples.

## Test plan
- [ ] `nf-test run subworkflows/msk/netmhcstabandpan/tests/main.nf.test`
- [ ] Run pipeline with `-profile test,docker` on a samplesheet that has no SV input and confirm netMHC stage executes for those samples
- [ ] Spot-check a samplesheet that includes SV data to confirm no regression
